### PR TITLE
add support for aliases and some aliases

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -22,6 +22,10 @@ cmd-doc() {
     return;
 }
 
+cmd-alias() {
+    return;
+}
+
 cmd-get-doc() {
     # callee
     # echo ${FUNCNAME[1]}
@@ -44,10 +48,14 @@ cmd-help() {
     local name=$1
     local prefix=$2
     local commands=$(compgen -A function | awk "/--/{next;} /^$prefix-/{sub(\"$prefix-\",\"\"); print;}")
+    local prefix_aliases=$(cmd-get-aliases ops-$prefix)
     local verbose=0
 
     echo
     echo "Usage: $name <command>"
+    if [[ -n "$prefix_aliases" ]]; then
+        echo "Aliases: $prefix_aliases"
+    fi
     echo
     echo "Available commands:"
 
@@ -55,11 +63,37 @@ cmd-help() {
         local IFS=$'\n'
         for line in $commands
         do
-            echo -e "  ${GREEN}$line${RESTORE}\t$(cmd-get-doc $prefix-$line | head -n 1)"
+            local aliases="$(cmd-get-aliases $prefix-$line)"
+            if [[ -n "$aliases" ]]; then
+                echo -e "  ${GREEN}$line ($aliases)${RESTORE}\t$(cmd-get-doc $prefix-$line | head -n 1)"
+            else
+                echo -e "  ${GREEN}$line${RESTORE}\t$(cmd-get-doc $prefix-$line | head -n 1)"
+            fi
         done
     ) | column -t -s $'\t'
 
     echo
+}
+
+cmd-get-aliases() {
+    declare -f $1 \ |
+        awk '/^[ \s]*cmd-alias /{print;}' | \
+        sed -E 's/^ *cmd-alias +(.*);$/\1/'
+}
+
+find-alias() {
+    local prefix=$1
+    local name=$2
+    local commands=$(compgen -A function | awk "/--/{next;} /^$prefix-/{sub(\"$prefix-\",\"\"); print;}")
+
+    local IFS=$'\n'
+    for cmd in $commands
+    do
+        if [[ "$(cmd-get-aliases $prefix-$cmd)" == @(|* )"$name"@(| *) ]]; then
+            echo $cmd
+            exit
+        fi
+    done
 }
 
 cmd-run() {
@@ -67,6 +101,13 @@ cmd-run() {
     local command="$2"
     shift
     shift
+
+    if [[ -n $command ]]; then
+        alias=$(find-alias $prefix $command)
+        if [[ -n $alias ]]; then
+            command=$alias
+        fi
+    fi
 
     [[ $(type -t $prefix-help) != 'function' ]]
     local has_help=$?

--- a/ops.sh
+++ b/ops.sh
@@ -195,6 +195,7 @@ _ops-mc() {
 
 ops-mariadb() {
     cmd-doc "MariaDB-specific commands"
+    cmd-alias my
 
     cmd-run mariadb "$@"
 }
@@ -205,6 +206,7 @@ mariadb-help() {
 }
 
 mariadb-cli() {
+    cmd-alias sh
     system-shell-exec mariadb mysql "${@}"
 }
 
@@ -223,6 +225,7 @@ mariadb-create() {
 }
 
 mariadb-list() {
+    cmd-alias ls
     ops-exec mariadb mysql --column-names=FALSE -e "show databases;" | \
         grep -v "^information_schema$" | \
         grep -v "^performance_schema$" | \
@@ -313,6 +316,7 @@ ops-ps() {
 }
 
 psql-cli() {
+    cmd-alias sh
     system-shell-exec postgres psql -U postgres "$@"
 }
 
@@ -331,6 +335,7 @@ psql-run() {
 }
 
 psql-list() {
+    cmd-alias ls
     ops-exec postgres psql -U postgres -t -c "SELECT datname FROM pg_database WHERE datname NOT IN ('template0', 'template1', 'postgres')" | \
     sed -e "s/^ *//" -e "/^$/d"
 }
@@ -361,6 +366,7 @@ psql-help() {
 
 ops-psql() {
     cmd-doc "PostreSQL-specific commands"
+    cmd-alias pg
 
     cmd-run psql "$@"
 }
@@ -408,6 +414,7 @@ ops-restart() {
 
 ops-shell() {
     cmd-doc "Enter shell or execute command"
+    cmd-alias sh
 
     local id=$(system-docker-compose ps -q $OPS_SHELL_BACKEND)
     local project=$(project-name)
@@ -426,6 +433,7 @@ ops-shell() {
 
 ops-link() {
     cmd-doc "Link and start project-specific containers"
+    cmd-alias ln
 
     local project_name=$(project-name)
 
@@ -474,6 +482,7 @@ ops-stats() {
 
 ops-start() {
     cmd-doc "Start services"
+    cmd-alias up
 
     echo 'Starting ops services...'
     echo
@@ -505,6 +514,7 @@ ops-start() {
 
 ops-stop() {
     cmd-doc "Stop services"
+    cmd-alias down
 
     system-stop
 
@@ -677,6 +687,7 @@ _ops-jq() {
 
 ops-system() {
     cmd-doc "System-specific commands"
+    cmd-alias sys
 
     cmd-run system "$@"
 }


### PR DESCRIPTION
This pull request adds the ability to set aliases for commands and command groups through the fake function `cmd-alias`. The functionality is very similar to how `cmd-doc` works. There's probably an argument to make for reworking both to not use `declare -f`, but I don't think that's necessary yet.

I also picked a handful of things to add aliases for.