### PR TITLE
Support working directories with spaces

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -29,7 +29,7 @@ declare -rx OPS_WORKING_DIR=$(pwd)
 cd $(dirname $0)
 cd $(dirname $(ls -l $0 | awk '{print $NF}'))
 declare -rx OPS_SCRIPT_DIR=$(pwd)
-cd $OPS_WORKING_DIR
+cd "$OPS_WORKING_DIR"
 
 # get version from VERSION file
 


### PR DESCRIPTION
Wrapping $OPS_WORKING_DIR in quotes for the cd command so that we can call mariadb-import from a path that contains spaces.

Example:
`kyle@MyMac:/Volumes/Client Drive/Imarc/backups/ $ ops mariadb import backup.sql`