### PR TITLE
Comply with XDG Specification and global ops-commands.sh

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -1204,6 +1204,10 @@ declare -x OPS_SHELL_USER=${OPS_SHELL_USER-"www-data"}
 
 # load custom commands
 
+if [[ -f "$OPS_CONFIG/ops-commands.sh" ]]; then
+    source "$OPS_CONFIG/ops-commands.sh"
+fi
+
 if [[ -f "$OPS_SITES_DIR/$OPS_PROJECT_NAME/ops-commands.sh" ]]; then
     source "$OPS_SITES_DIR/$OPS_PROJECT_NAME/ops-commands.sh"
 fi

--- a/ops.sh
+++ b/ops.sh
@@ -911,10 +911,19 @@ system-config() {
 
 system-install() {
     if [[ ! -d $OPS_HOME ]]; then
+        mkdir -p $(dirname $OPS_HOME)
         cp -R $OPS_SCRIPT_DIR/home $OPS_HOME
 
+        if [ -n "$XDG_CURRENT_DESKTOP" ]; then
+            OPS_BIN="${OPS_BIN-"$HOME/.local/bin"}"
+        fi
+
+        if [ -n "$OPS_BIN" ]; then
+            ln -s $OPS_HOME/ops.sh $OPS_BIN/ops
+        fi
+
         if [[ ! -d $OPS_CONFIG ]]; then
-            mkdir $OPS_CONFIG
+            mkdir -p $OPS_CONFIG
             mv $OPS_HOME/config $OPS_CONFIG/config
         fi
 
@@ -1103,11 +1112,11 @@ main() {
 # options that can be overidden by environment
 
 if [ -n "$XDG_CURRENT_DESKTOP" ]; then
-    export OPS_HOME="${OPS_HOME-"$HOME/.local/ops"}"
-    export OPS_CONFIG="${OPS_CONFIG-"$HOME/.config/ops"}"
+    export OPS_HOME="${OPS_HOME-"${XDG_DATA_HOME-"$HOME/.local/share/ops"}"}"
+    export OPS_CONFIG="${OPS_CONFIG-"${XDG_CONFIG_HOME-"$HOME/.config/ops"}"}"
 else
     export OPS_HOME="${OPS_HOME-"$HOME/.ops"}"
-    export OPS_CONFIG="${OPS_CONFIG-"$HOME/.ops/config"}"
+    export OPS_CONFIG="${OPS_CONFIG-"$HOME/.ops"}"
 fi
 
 # load config


### PR DESCRIPTION
Trying to follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to be slightly friendlier with linux desktops. It looks for `$XDG_CURRENT_DESKTOP` to determine whether to use XDG defaults and check for overrides `$XDG_DATA_HOME` and `$XDG_CONFIG_HOME` (per the spec) as well as the more globally applicable `$OPS_CONFIG` alongside `$OPS_HOME`.

I installed this locally and have it running like this now.

For better or worse, I also included support for `$OPS_CONFIG/ops-commands.sh`, a global ops-commands.sh that can be used to add commands you want across all projects. 