### PR TITLE
Update docker-compose files to include extra_hosts

### DIFF
--- a/home/docker-compose/backends/apache-php72.yml
+++ b/home/docker-compose/backends/apache-php72.yml
@@ -15,6 +15,8 @@ services:
       - OPS_PHP_XDEBUG=${OPS_PHP_XDEBUG}
 
     dns: $OPS_SERVICES_DNS_IP
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     networks:
       - backend

--- a/home/docker-compose/backends/apache-php73.yml
+++ b/home/docker-compose/backends/apache-php73.yml
@@ -15,6 +15,8 @@ services:
       - OPS_PHP_XDEBUG=${OPS_PHP_XDEBUG}
 
     dns: $OPS_SERVICES_DNS_IP
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     networks:
       - backend

--- a/home/docker-compose/backends/apache-php74.yml
+++ b/home/docker-compose/backends/apache-php74.yml
@@ -15,6 +15,8 @@ services:
       - OPS_PHP_XDEBUG=${OPS_PHP_XDEBUG}
 
     dns: $OPS_SERVICES_DNS_IP
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     networks:
       - backend

--- a/home/docker-compose/backends/apache-php80.yml
+++ b/home/docker-compose/backends/apache-php80.yml
@@ -15,6 +15,8 @@ services:
       - OPS_PHP_XDEBUG=${OPS_PHP_XDEBUG}
 
     dns: $OPS_SERVICES_DNS_IP
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     networks:
       - backend

--- a/home/docker-compose/backends/apache-php81.yml
+++ b/home/docker-compose/backends/apache-php81.yml
@@ -15,6 +15,8 @@ services:
       - OPS_PHP_XDEBUG=${OPS_PHP_XDEBUG}
 
     dns: $OPS_SERVICES_DNS_IP
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     networks:
       - backend

--- a/home/docker-compose/backends/apache-php82.yml
+++ b/home/docker-compose/backends/apache-php82.yml
@@ -15,6 +15,8 @@ services:
       - OPS_PHP_XDEBUG=${OPS_PHP_XDEBUG}
 
     dns: $OPS_SERVICES_DNS_IP
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     networks:
       - backend


### PR DESCRIPTION
This pull request fixes xdebug when using Docker for Linux, by manually adding the 'host.docker.internal' DNS name.
Ops' xdebug config refers to the debugging client's host using the name 'host.docker.internal', which only exists by default on Docker Desktop; so xdebug can't connect to the host machine on Docker for Linux. This PR updates the docker-compose files for the apache backends to manually add that 'host.docker.internal' to the hosts file using Docker's magic `host-gateway` reference. This is the official approach and shouldn't affect Docker Desktop - see [this issue](https://github.com/docker/for-linux/issues/264#issuecomment-965465879).
I've tested and this correctly updates the containers' hosts file, and xdebug is working now.