### PR TITLE
add 'ops root' command

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -525,6 +525,11 @@ ops-shell() {
     fi
 }
 
+ops-root() {
+  cmd-doc "connect as root to an ops container"
+  OPS_SHELL_USER=root ops-shell
+}
+
 ops-www() {
     cmd-doc "Open current project in web browser."
     local project=$(project-name)


### PR DESCRIPTION
Add 'ops root' as what I think is a reasonable default command to provide for people to use. If you want to bury this more, I understand, don't merge.