### PR TITLE
add 'ops ssh' command

### DIFF
--- a/ops.sh
+++ b/ops.sh
@@ -525,6 +525,11 @@ ops-shell() {
     fi
 }
 
+ops-ssh() {
+  cmd-doc "SSH into the project's server."
+  ssh $(ops env OPS_PROJECT_REMOTE_HOST) "$@"
+}
+
 ops-www() {
     cmd-doc "Open current project in web browser."
     local project=$(project-name)


### PR DESCRIPTION
Adds an 'ops ssh' command that SSHs into `OPS_PROJECT_REMOTE_HOST`. I think this might also help debug ops sync issues or such.